### PR TITLE
feat: enhance rundown with speaker info, maintain conciseness

### DIFF
--- a/src/features/rundown_feature.py
+++ b/src/features/rundown_feature.py
@@ -173,16 +173,17 @@ class RundownFeature:
             print(f"Total messages included: {len(messages_2d)}")
 
             prompt = (
-                "You are a Discord summarization bot. Your task is to provide a very brief, high-level summary of the following conversation. "
-                "The entire response must be extremely concise and well under 1000 characters. "
-                "First, write a one or two-sentence general summary. Then, list the key topics or questions discussed as bullet points. "
-                "Do not summarize each person's contribution unless it was a major, conversation-defining point. "
+                "You are a Discord summarization bot. Provide a concise summary of the conversation, "
+                "highlighting the main topics discussed and who contributed to each. "
+                "Keep the overall summary brief, aiming for readability. "
+                "Use bullet points to mention key speakers and their main points. "
+                "The entire response should be under 1200 characters. "
                 f"Here is the conversation history, where each item is [sender, message]:\n\n{messages_2d}"
             )
 
             system_instruction = (
-                "Create an extremely brief summary of the key topics in the provided Discord messages. "
-                "The entire output must be very short. Use a single general summary sentence followed by bullet points of topics."
+                "Summarize the key topics and associated speakers from the provided Discord messages concisely. "
+                "Prioritize readability with a brief overview and bulleted speaker contributions."
             )
 
             async with ctx.typing():


### PR DESCRIPTION
This commit improves the `!rundown` command to include information about who said what in the generated summaries while still maintaining conciseness.

The Gemini prompt has been refined to explicitly request a summary that highlights main topics and the contributors to each. It encourages starting with a general overview and then using bullet points for key speakers and their main points. The character truncation limit has also been slightly adjusted to accommodate this additional information without making the summaries excessively long. This change aims to provide more informative rundowns for users.

**Before (Previous Rundown Output):**

```
Ts da runDown :3 for the 598 messages from the past 10 hours:
Friends discuss PC hardware upgrades and streaming, cloud computing business ideas, a recent breakup, and GitHub pull request approval processes.

PC build specs (GPU, RAM, CPU) for 1440p gaming and budget.
Cloud computing/rental server business ideas.
Wireless PC streaming and electricity costs.
A user's recent breakup drama, including family involvement.
GitHub pull request (PR) approval process issues.
Internet service speeds and pricing.
```

**After (New Rundown Output Example):**

```
Ts da runDown :3 for the 598 messages from the past 10 hours:
The conversation covers PC building, cloud computing business ideas, bqqsim's breakup, and developer workflow issues.

bqqsim: Debates streaming vs. PC build, asks about GPU (6700xt/6800xt) and RAM (16GB/32GB) for 1440p gaming, and shares details of his recent breakup.
MWS: Jokes about a "new" business idea for renting cloud servers/VMs for Windows or games (which hamza points out is not new), and comments on bqqsim's relationship.
hamza: Counters MWS's business idea by referencing existing services (Nvidia Go, Hostkey); advises on PC components and budget for a 999 CAD build; debates 16GB vs 32GB RAM for gaming.
Sheikh Hamood: Discusses GPU coil whine, electricity bills, and jokes about PR approval processes.
Carpenter: Expresses frustration with PR approvals, emphasizing the need for testing logs before merging.
```