### PR TITLE
fix: revert run_in_executor to use positional args

### DIFF
--- a/src/features/autoTranslation_feature.py
+++ b/src/features/autoTranslation_feature.py
@@ -53,7 +53,7 @@ class ArabicTranslateFeature:
 
             if self.arabic_pattern.search(message.content):
                 translated_text = await self.bot.loop.run_in_executor(
-                    func=self._translate_with_gemini, args=(message.content,)
+                    None, self._translate_with_gemini, message.content
                 )
 
                 if translated_text is None:


### PR DESCRIPTION
The run_in_executor method doesn't accept keyword arguments. This reverts the changes from f6b9fb2 to use positional arguments instead.