### PR TITLE
refactor: modularize bot structure, add universal tester-channel filter

### DIFF
--- a/src/botcore/bot.py
+++ b/src/botcore/bot.py
@@ -1,0 +1,22 @@
+from discord.ext import commands
+from discord import Intents
+from botcore.loader import load_all_cogs, maybe_start_watcher
+from botcore.event_filter import should_ignore_event
+
+
+class MyBot(commands.Bot):
+    def __init__(self, *args, **kwargs):
+        intents = kwargs.pop("intents", Intents.default())
+        intents.message_content = True
+        super().__init__(*args, intents=intents, **kwargs)
+
+    async def setup_hook(self):
+        """Load cogs and start the dev watcher if needed."""
+        await load_all_cogs(self)
+        maybe_start_watcher(self)
+
+    async def _run_event(self, coro, event_name, *args, **kwargs):
+        """Universal event filter that ignores tester channel in prod."""
+        if should_ignore_event(event_name, args):
+            return
+        await super()._run_event(coro, event_name, *args, **kwargs)

--- a/src/botcore/event_filter.py
+++ b/src/botcore/event_filter.py
@@ -1,0 +1,23 @@
+from config.manager import ConfigManager
+
+
+def should_ignore_event(event_name: str, args: tuple) -> bool:
+    """
+    Returns True if the event should be ignored (e.g., messages in tester channel when in prod).
+    """
+    config = ConfigManager()
+
+    if config.get_app_env() != "prod":
+        return False
+
+    if event_name.startswith("on_message") or event_name in {
+        "on_reaction_add",
+        "on_reaction_remove",
+        "on_message_edit",
+        "on_typing",
+    }:
+        message = args[0] if args else None
+        if message and message.channel.id == config.get_tester_channel_id():
+            return True
+
+    return False

--- a/src/botcore/loader.py
+++ b/src/botcore/loader.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from config.manager import ConfigManager
+from reloader.watcher import start_watcher
+
+
+async def load_all_cogs(bot):
+    """Load all cogs from the cogs directory."""
+    cogs_folder = Path(__file__).parent.parent / "cogs"
+    print("Loading cogs...")
+
+    for file_path in cogs_folder.glob("*.py"):
+        if not file_path.name.startswith("__"):
+            try:
+                await bot.load_extension(f"cogs.{file_path.stem}")
+                print(f"Loaded cog: {file_path.name}")
+            except Exception as e:
+                print(f"Failed to load {file_path.name}: {e}")
+
+    print("Cogs loaded successfully.")
+
+
+def maybe_start_watcher(bot):
+    """Start hot-reload watcher in development mode."""
+    config = ConfigManager()
+    if config.get_app_env() == "dev":
+        start_watcher(bot)

--- a/src/cogs/auto_translation.py
+++ b/src/cogs/auto_translation.py
@@ -2,7 +2,7 @@ import re
 from google.genai import types
 from discord.ext import commands
 from discord import Message
-from gemini_service import GeminiService
+from services.gemini_service import GeminiService
 
 
 class AutoTranslationCog(commands.Cog, name="ArabicTranslate"):

--- a/src/cogs/gemini.py
+++ b/src/cogs/gemini.py
@@ -2,7 +2,7 @@ from google.genai import types
 from discord.ext import commands
 from discord import Message
 from collections import OrderedDict
-from gemini_service import GeminiService
+from services.gemini_service import GeminiService
 
 
 class GeminiCog(commands.Cog, name="Gemini"):

--- a/src/cogs/rundown.py
+++ b/src/cogs/rundown.py
@@ -2,7 +2,7 @@ import re
 from google.genai import types
 from discord.ext import commands
 from datetime import datetime, timezone, timedelta
-from gemini_service import GeminiService
+from services.gemini_service import GeminiService
 
 
 class RundownCog(commands.Cog, name="Rundown"):

--- a/src/config/manager.py
+++ b/src/config/manager.py
@@ -40,7 +40,7 @@ class ConfigManager:
             self._app_env = "prod"
 
         # Store DOTENV_PATH for error messages and clarity
-        CURRENT_SCRIPT_DIR = Path(__file__).resolve().parent
+        CURRENT_SCRIPT_DIR = Path(__file__).resolve().parent.parent
         self._dotenv_path = CURRENT_SCRIPT_DIR.parent / ".env"
 
         # Load .env file

--- a/src/reloader/watcher.py
+++ b/src/reloader/watcher.py
@@ -16,7 +16,7 @@ class SmartReloader(FileSystemEventHandler):
 
     def __init__(self, bot):
         self.bot = bot
-        self.root_path = Path(__file__).parent.resolve()
+        self.root_path = Path(__file__).parent.parent.resolve()
         self.cogs_folder_name = "cogs"
 
     def on_modified(self, event):
@@ -89,7 +89,7 @@ class SmartReloader(FileSystemEventHandler):
 
 def start_watcher(bot):
     """Starts watching the project directory for file changes."""
-    project_root = Path(__file__).parent.resolve()
+    project_root = Path(__file__).parent.parent.resolve()
     event_handler = SmartReloader(bot)
     observer = Observer()
     observer.schedule(event_handler, str(project_root), recursive=True)

--- a/src/services/gemini_service.py
+++ b/src/services/gemini_service.py
@@ -1,6 +1,6 @@
 import google.genai as genai
 from google.genai import types, errors
-from config import ConfigManager
+from config.manager import ConfigManager
 from typing import List
 
 


### PR DESCRIPTION
### Overview

This PR refactors the Discord bot project to a modular structure for better maintainability and scalability.  

### Changes
- Bot logic moved to `botcore/bot.py`
- Cog loading and dev reloader logic centralized in `botcore/loader.py`
- Universal event filter for ignoring tester channel in production added to `botcore/event_filter.py`
- ConfigManager moved to `config/manager.py`
- GeminiService moved to `services/gemini_service.py`
- Hot-reloader code moved to `reloader/watcher.py`
- `main.py` reduced to a minimal bot entrypoint

### Benefits
- Cleaner separation of concerns
- Easy to add more cogs, services, or middleware
- Universal handling of tester-channel ignoring in production
- Easier testing and debugging
