### PR TITLE
Refactor LLM orchestration to use LangChain & Fix Ollama Fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ discord.py
 python-dotenv
 watchdog
 litellm
+langchain
+langchain-community
+langchain-core

--- a/src/cogs/auto_translation.py
+++ b/src/cogs/auto_translation.py
@@ -1,7 +1,8 @@
 import re
 from discord.ext import commands
 from discord import Message
-from services.litellm_service import LiteLLMService, LLMFallbackError
+from services.litellm_service import LiteLLMService
+from langchain_core.prompts import ChatPromptTemplate
 
 
 class AutoTranslationCog(commands.Cog, name="ArabicTranslate"):
@@ -10,34 +11,15 @@ class AutoTranslationCog(commands.Cog, name="ArabicTranslate"):
         self.llm_service = LiteLLMService()
         self.arabic_pattern = re.compile(r"[\u0600-\u06FF]")
 
-    def _get_translation_args(self, text: str):
-        """Helper to generate conversation history and instruction."""
-        system_instruction = (
-            "Translate the following Arabic text into English. "
-            "Only return the translation, no explanations."
+        self.prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "Translate the following Arabic text into English. Only return the translation, no explanations.",
+                ),
+                ("human", "{text}"),
+            ]
         )
-        conversation_history = [{"role": "user", "content": text}]
-        return conversation_history, system_instruction
-
-    def _translate_with_gemini(self, text: str) -> str | None:
-        """Send Arabic text to Gemini and return English translation."""
-        history, instr = self._get_translation_args(text)
-        translation = self.llm_service.make_gemini_request(history, instr)
-
-        if not translation or translation.startswith("Sorry,"):
-            print(f"ArabicTranslateFeature: Translation error: {translation}")
-            return None
-        return translation
-
-    def _translate_with_ollama(self, text: str) -> str | None:
-        """Fallback translation method using local Ollama model."""
-        history, instr = self._get_translation_args(text)
-        translation = self.llm_service.make_ollama_request(history, instr)
-
-        if not translation or translation.startswith("Sorry,"):
-            print(f"ArabicTranslateFeature: Ollama translation error: {translation}")
-            return None
-        return translation
 
     @commands.Cog.listener()
     async def on_message(self, message: Message):
@@ -46,20 +28,29 @@ class AutoTranslationCog(commands.Cog, name="ArabicTranslate"):
             return
 
         if self.arabic_pattern.search(message.content):
-            try:
-                translated_text = await self.bot.loop.run_in_executor(
-                    None, self._translate_with_gemini, message.content
-                )
-            except LLMFallbackError:
-                await message.reply(
-                    "⚠️ **Translation API failed.** Falling back to local `llama3.2`. This may take a moment...",
-                    mention_author=False,
-                )
-                translated_text = await self.bot.loop.run_in_executor(
-                    None, self._translate_with_ollama, message.content
-                )
+            prompt_value = await self.prompt.ainvoke({"text": message.content})
+            translated_text = None
 
-            if translated_text is None:
+            async with message.channel.typing():
+                try:
+                    ai_msg = await self.llm_service.primary_llm.ainvoke(prompt_value)
+                    translated_text = ai_msg.content
+                except Exception as e:
+                    print(f"ArabicTranslateFeature: API Error: {e}")
+                    await message.reply(
+                        "⚠️ **Translation API failed.** Falling back to local `llama3.2`. This may take a moment...",
+                        mention_author=False,
+                    )
+                    try:
+                        ai_msg = await self.llm_service.fallback_llm.ainvoke(
+                            prompt_value
+                        )
+                        translated_text = ai_msg.content
+                    except Exception as fallback_e:
+                        print(f"ArabicTranslateFeature: Fallback error: {fallback_e}")
+                        return
+
+            if not translated_text or translated_text.startswith("Sorry,"):
                 print("Translation failed")
                 return
 

--- a/src/cogs/gemini.py
+++ b/src/cogs/gemini.py
@@ -1,16 +1,27 @@
 from discord.ext import commands
 from discord import Message
 from collections import OrderedDict
-from services.litellm_service import LiteLLMService, LLMFallbackError
+from services.litellm_service import LiteLLMService
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_community.chat_message_histories import ChatMessageHistory
 
 
 class GeminiCog(commands.Cog, name="Gemini"):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.llm_service = LiteLLMService()
-        self.conversations: OrderedDict[int, list[dict]] = OrderedDict()
+        self.conversations: OrderedDict[int, ChatMessageHistory] = OrderedDict()
         self.MAX_ACTIVE_CONVERSATIONS = 50
         self.MAX_CONVERSATION_HISTORY_MESSAGES = 50
+
+        # Clean LangChain Prompt Template (No weird meta-instructions)
+        self.prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", "Please keep your response concise and brief."),
+                MessagesPlaceholder(variable_name="history"),
+                ("human", "{question}"),
+            ]
+        )
 
     def _cleanup_old_conversations(self):
         """Removes the oldest conversation histories if exceeding MAX_ACTIVE_CONVERSATIONS."""
@@ -25,67 +36,83 @@ class GeminiCog(commands.Cog, name="Gemini"):
             return
 
         user_current_prompt_text = prompt
-        system_instruction = "Please keep your response concise and brief."
-        current_conversation_history: list[dict] = []
+        current_history = ChatMessageHistory()
+        cache_loaded = False
 
-        thread = []
-        latest_message = ctx.message
-
-        while True:
-            thread.append(
-                f"[{latest_message.created_at.strftime('%Y-%m-%d %H:%M:%S')}] "
-                f"{latest_message.author}: {latest_message.content}"
-            )
-
-            if not latest_message.reference:
-                break
-
-            ref = latest_message.reference
-            if ref and ref.message_id:
-                latest_message = await ctx.channel.fetch_message(ref.message_id)
-            else:
-                break
-
-        if thread and len(thread) > 0:
-            thread_history = "\n".join(reversed(thread))
-            print(f"Thread history: {thread_history}")
-            user_current_prompt_text = f"This is the thread history that you are taking into context:\n{thread_history}\n\nNow responding to: {user_current_prompt_text}. if it makes sense to reply with the thread in context, do so"
-
+        # 1. Check if replying to the bot's known conversation in memory
         if ctx.message.reference and ctx.message.reference.resolved:
             replied_message: Message = ctx.message.reference.resolved  # type: ignore
             if replied_message.author == self.bot.user:
                 retrieved_history = self.conversations.get(replied_message.id)
                 if retrieved_history:
-                    current_conversation_history = list(retrieved_history)
+                    # Shallow copy the message list to branch off seamlessly
+                    current_history.messages = list(retrieved_history.messages)
                     self.conversations.move_to_end(replied_message.id)
+                    cache_loaded = True
 
-        current_conversation_history.append(
-            {"role": "user", "content": user_current_prompt_text}
-        )
+        # 2. If no cache was loaded but there's a reply chain (e.g. bot restarted, or replying to human),
+        # dynamically build the history using proper LangChain AI/Human roles.
+        if (
+            not cache_loaded
+            and ctx.message.reference
+            and ctx.message.reference.message_id
+        ):
+            thread_msgs = []
+            curr_msg_id = ctx.message.reference.message_id
 
-        if len(current_conversation_history) > self.MAX_CONVERSATION_HISTORY_MESSAGES:
-            current_conversation_history = current_conversation_history[
+            # Traverse up the reply chain (limit to 10 to avoid hitting Discord rate limits)
+            for _ in range(10):
+                if not curr_msg_id:
+                    break
+                try:
+                    curr_msg = await ctx.channel.fetch_message(curr_msg_id)
+                    thread_msgs.append(curr_msg)
+                    if curr_msg.reference and curr_msg.reference.message_id:
+                        curr_msg_id = curr_msg.reference.message_id
+                    else:
+                        break
+                except Exception as e:
+                    print(f"GeminiCog: Failed to fetch thread message: {e}")
+                    break
+
+            # Add the fetched messages chronologically to LangChain history
+            for msg in reversed(thread_msgs):
+                if msg.author == self.bot.user:
+                    current_history.add_ai_message(msg.content)
+                else:
+                    # Prefix human messages with their name so the bot knows who said what
+                    current_history.add_user_message(
+                        f"{msg.author.display_name}: {msg.content}"
+                    )
+
+        # Truncate history to save tokens
+        if len(current_history.messages) > self.MAX_CONVERSATION_HISTORY_MESSAGES:
+            current_history.messages = current_history.messages[
                 -self.MAX_CONVERSATION_HISTORY_MESSAGES :
             ]
 
+        # Format the final prompt value to inject into the LLM
+        prompt_value = await self.prompt.ainvoke(
+            {"history": current_history.messages, "question": user_current_prompt_text}
+        )
+
         async with ctx.typing():
             try:
-                raw_ai_response_text = await self.bot.loop.run_in_executor(
-                    None,
-                    self.llm_service.make_gemini_request,
-                    current_conversation_history,
-                    system_instruction,
-                )
-            except LLMFallbackError:
+                # Native async LangChain invoke
+                ai_msg = await self.llm_service.primary_llm.ainvoke(prompt_value)
+                raw_ai_response_text = ai_msg.content
+            except Exception as e:
+                print(f"Gemini API Error: {e}")
                 await ctx.reply(
                     "⚠️ **Gemini API failed.** Falling back to local `llama3.2` model. This runs locally on the Raspberry Pi and may take a moment..."
                 )
-                raw_ai_response_text = await self.bot.loop.run_in_executor(
-                    None,
-                    self.llm_service.make_ollama_request,
-                    current_conversation_history,
-                    system_instruction,
-                )
+                try:
+                    # Async local fallback invoke
+                    ai_msg = await self.llm_service.fallback_llm.ainvoke(prompt_value)
+                    raw_ai_response_text = ai_msg.content
+                except Exception as fallback_e:
+                    print(f"Local Fallback Error: {fallback_e}")
+                    raw_ai_response_text = "Sorry, an unknown error occurred and no response was generated from the AI."
 
         if not raw_ai_response_text:
             await ctx.reply(
@@ -95,6 +122,7 @@ class GeminiCog(commands.Cog, name="Gemini"):
 
         is_error_response = raw_ai_response_text.startswith("Sorry,")
 
+        # Chunk the response for Discord's character limits
         display_text_parts = []
         if not is_error_response and len(raw_ai_response_text) > 2000:
             current_part = ""
@@ -110,33 +138,25 @@ class GeminiCog(commands.Cog, name="Gemini"):
             display_text_parts.append(raw_ai_response_text)
 
         sent_discord_messages: list[Message] = []
-        for i, text_content_for_part in enumerate(display_text_parts):
+        for text_content_for_part in display_text_parts:
             if not text_content_for_part.strip():
                 continue
 
-            message_to_send_discord = text_content_for_part
-
             try:
-                msg_obj = await ctx.reply(message_to_send_discord)
+                msg_obj = await ctx.reply(text_content_for_part)
                 sent_discord_messages.append(msg_obj)
             except Exception as e:
                 print(f"Error sending Discord message part: {e}")
                 await ctx.reply(f"Error sending part of the response: {e}")
 
+        # Update and map memory to the final message ID
         if sent_discord_messages and not is_error_response:
             final_sent_message_id = sent_discord_messages[-1].id
 
-            history_to_store = list(current_conversation_history)
-            history_to_store.append(
-                {"role": "assistant", "content": raw_ai_response_text}
-            )
+            current_history.add_user_message(user_current_prompt_text)
+            current_history.add_ai_message(raw_ai_response_text)
 
-            if len(history_to_store) > self.MAX_CONVERSATION_HISTORY_MESSAGES:
-                history_to_store = history_to_store[
-                    -self.MAX_CONVERSATION_HISTORY_MESSAGES :
-                ]
-
-            self.conversations[final_sent_message_id] = history_to_store
+            self.conversations[final_sent_message_id] = current_history
             self._cleanup_old_conversations()
 
 

--- a/src/cogs/rundown.py
+++ b/src/cogs/rundown.py
@@ -1,13 +1,27 @@
 import re
 from discord.ext import commands
 from datetime import datetime, timezone, timedelta
-from services.litellm_service import LiteLLMService, LLMFallbackError
+from services.litellm_service import LiteLLMService
+from langchain_core.prompts import ChatPromptTemplate
 
 
 class RundownCog(commands.Cog, name="Rundown"):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.llm_service = LiteLLMService()
+
+        self.prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "Summarize the key topics and associated speakers from the provided Discord messages concisely. Prioritize readability with a brief overview and bulleted speaker contributions.",
+                ),
+                (
+                    "human",
+                    "You are a Discord summarization bot. Provide a concise summary of the conversation, highlighting the main topics discussed and who contributed to each. Keep the overall summary brief, aiming for readability. Use bullet points to mention key speakers and their main points. The entire response should be under 1200 characters. Here is the conversation history, where each item is [sender, message]:\n\n{messages}",
+                ),
+            ]
+        )
 
     _DURATION_RE = re.compile(r"^\s*(\d+)\s*([mMhH]?)\s*$")
 
@@ -68,38 +82,23 @@ class RundownCog(commands.Cog, name="Rundown"):
 
         print(f"Total messages included: {len(messages_2d)}")
 
-        prompt = (
-            "You are a Discord summarization bot. Provide a concise summary of the conversation, "
-            "highlighting the main topics discussed and who contributed to each. "
-            "Keep the overall summary brief, aiming for readability. "
-            "Use bullet points to mention key speakers and their main points. "
-            "The entire response should be under 1200 characters. "
-            f"Here is the conversation history, where each item is [sender, message]:\n\n{messages_2d}"
-        )
-
-        system_instruction = (
-            "Summarize the key topics and associated speakers from the provided Discord messages concisely. "
-            "Prioritize readability with a brief overview and bulleted speaker contributions."
-        )
+        prompt_value = await self.prompt.ainvoke({"messages": str(messages_2d)})
+        summary = None
 
         async with ctx.typing():
             try:
-                summary = await self.bot.loop.run_in_executor(
-                    None,
-                    self.llm_service.make_gemini_request,
-                    [{"role": "user", "content": prompt}],
-                    system_instruction,
-                )
-            except LLMFallbackError:
+                ai_msg = await self.llm_service.primary_llm.ainvoke(prompt_value)
+                summary = ai_msg.content
+            except Exception as e:
+                print(f"Rundown: API Error: {e}")
                 await ctx.reply(
                     "⚠️ **Gemini API failed.** Falling back to local `llama3.2` to summarize. This runs locally on the Raspberry Pi and may take a moment..."
                 )
-                summary = await self.bot.loop.run_in_executor(
-                    None,
-                    self.llm_service.make_ollama_request,
-                    [{"role": "user", "content": prompt}],
-                    system_instruction,
-                )
+                try:
+                    ai_msg = await self.llm_service.fallback_llm.ainvoke(prompt_value)
+                    summary = ai_msg.content
+                except Exception as fallback_e:
+                    print(f"Rundown: Fallback Error: {fallback_e}")
 
         if not summary:
             await ctx.reply("Sorry, the AI did not return a summary.")

--- a/src/services/litellm_service.py
+++ b/src/services/litellm_service.py
@@ -1,13 +1,5 @@
-import litellm
-from litellm import completion
+from langchain_community.chat_models import ChatLiteLLM
 from config.manager import ConfigManager
-from typing import List, Dict, Optional
-
-
-class LLMFallbackError(Exception):
-    """Raised when the Gemini API fails, signaling a need to fallback to a local LLM."""
-
-    pass
 
 
 class LiteLLMService:
@@ -28,73 +20,18 @@ class LiteLLMService:
         if not self.gemini_api_key:
             raise ValueError("Gemini API key is not configured.")
 
-        # LiteLLM routing prefix for Gemini
         self.gemini_model_name = "gemini/gemini-3.1-flash-lite-preview"
+
+        # Primary LLM via LangChain (Gemini)
+        self.primary_llm = ChatLiteLLM(
+            model=self.gemini_model_name, api_key=self.gemini_api_key
+        )
+
+        # Fallback LLM via LangChain (Local Ollama on Raspberry Pi)
+        self.fallback_llm = ChatLiteLLM(
+            model="ollama_chat/llama3.2",
+            api_base="http://localhost:11434",
+            model_kwargs={"timeout": 180},
+        )
+
         self._initialized = True
-
-    def _prepare_messages(
-        self,
-        conversation_contents: List[Dict[str, str]],
-        system_instruction: Optional[str],
-    ) -> List[Dict[str, str]]:
-        messages = []
-        if system_instruction:
-            messages.append({"role": "system", "content": system_instruction})
-        messages.extend(conversation_contents)
-        return messages
-
-    def make_ollama_request(
-        self,
-        conversation_contents: List[Dict[str, str]],
-        system_instruction_text: Optional[str],
-    ) -> Optional[str]:
-        """
-        Fallback mechanism that uses a local Ollama instance running llama3.2 via LiteLLM
-        """
-        print("LiteLLM Service: Executing local Ollama fallback (llama3.2)...")
-        messages = self._prepare_messages(
-            conversation_contents, system_instruction_text
-        )
-
-        try:
-            response = completion(
-                model="ollama/llama3.2",
-                messages=messages,
-                api_base="http://localhost:11434",
-                timeout=180,  # Generous timeout since 3b models on a Pi are slow
-            )
-            return response.choices[0].message.content
-        except Exception as e:
-            print(f"LiteLLM Service: Ollama fallback error: {e}")
-            return "Sorry, both Gemini and the local fallback AI encountered an error."
-
-    def make_gemini_request(
-        self,
-        conversation_contents: List[Dict[str, str]],
-        system_instruction_text: Optional[str],
-    ) -> Optional[str]:
-        """
-        Makes a request to the Gemini API using LiteLLM. Raises LLMFallbackError if the API request fails.
-        """
-        if not conversation_contents:
-            print("LiteLLM Service: Conversation contents list is empty.")
-            return "Sorry, there's no conversation to continue with."
-
-        messages = self._prepare_messages(
-            conversation_contents, system_instruction_text
-        )
-
-        try:
-            response = completion(
-                model=self.gemini_model_name,
-                messages=messages,
-                api_key=self.gemini_api_key,
-            )
-            return response.choices[0].message.content
-
-        except litellm.exceptions.APIError as e:
-            print(f"LiteLLM Service: API Error: {e}")
-            raise LLMFallbackError(str(e))
-        except Exception as e:
-            print(f"LiteLLM Service: Unexpected error: {e}")
-            raise LLMFallbackError(str(e))


### PR DESCRIPTION
This PR migrates the bot's AI logic from manual LiteLLM dictionary manipulation to LangChain's modular abstractions, improving code readability and memory management. 

**Key Changes:**
* **LangChain Integration:** Implemented `ChatLiteLLM`, `ChatPromptTemplate`, and `ChatMessageHistory` to simplify prompt construction and context memory.
* **Native Async:** Replaced thread-blocking `run_in_executor` calls with LangChain's native `ainvoke`.
* **Smarter Context:** The `!ask` command now parses Discord's reply chain into proper `Human` and `AI` roles, allowing it to dynamically rebuild memory if the bot restarts.
* **Bug Fix:** Changed the fallback model prefix to `ollama_chat/llama3.2` so LiteLLM routes to the correct chat endpoint, preventing the local Llama model from hallucinating transcripts.